### PR TITLE
Add http response code to api exception

### DIFF
--- a/src/com/egeniq/utils/api/APIClient.java
+++ b/src/com/egeniq/utils/api/APIClient.java
@@ -425,7 +425,7 @@ public class APIClient extends AbstractHTTPClient {
             if (response.getStatusLine().getStatusCode() >= 400) {
                 try {
                     JSONObject object = new JSONObject(responseBody);
-                    throw new APIException(object.getString("code"), object.getString("message"), response.getStatusLine().getStatusCode(), null);
+                    throw new APIException(object.getString("code"), object.getString("message"), response.getStatusLine().getStatusCode());
                 } catch (JSONException e) {
                     throw new APIException(response.getStatusLine().getStatusCode(), e);
                 }

--- a/src/com/egeniq/utils/api/APIException.java
+++ b/src/com/egeniq/utils/api/APIException.java
@@ -35,6 +35,9 @@ public class APIException extends Exception {
 
     /**
      * Constructs an unknown API exception.
+     * 
+     * @param responseCode HTTPResponse code
+     * @param parent       Throwable parent
      */
     public APIException(int responseCode, Throwable parent) {
         this("unknown", "Unknown error", responseCode, parent);
@@ -55,9 +58,21 @@ public class APIException extends Exception {
      * 
      * @param code    Error code.
      * @param message Error message.
+     * @param parent  Throwable parent
      */
     public APIException(String code, String message, Throwable parent) {
         this(code, message, 0, parent);
+    }
+    
+    /**
+     * Constructs an API exception with the given code and message.
+     * 
+     * @param code         Error code.
+     * @param message      Error message.
+     * @param responseCode HTTPResponse code.
+     */
+    public APIException(String code, String message, int responseCode) {
+        this(code, message, responseCode, null);
     }
     
     /**


### PR DESCRIPTION
No I am not happy with this. But due to time contraints..

This addes HTTP status code to APIExceptions
